### PR TITLE
fix: Date parsing

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -45,14 +45,14 @@ export const getEndTime = (): number => {
   const meridiem = now.format("A");
   if (meridiem === "AM") {
     // We are in the morning (ante-meridiem), next lottery is at 06:00 AM.
-    return moment(`${now.format("MM DD YYYY")} 06:00:00 +0000`, "MM DD YYYY hh:mm:ss Z", true)
+    return moment(`${now.format("MM DD YYYY")} 06:00:00 +0000`, "MM DD YYYY HH:mm:ss Z", true)
       .add(12, "hours")
       .startOf("hour")
       .utc()
       .unix();
   } else if (meridiem === "PM") {
     // We are in the afternoon (post-meridiem), next lottery is at 06:00 PM.
-    return moment(`${now.format("MM DD YYYY")} 18:00:00 +0000`, "MM DD YYYY hh:mm:ss Z", true)
+    return moment(`${now.format("MM DD YYYY")} 18:00:00 +0000`, "MM DD YYYY HH:mm:ss Z", true)
       .add(12, "hours")
       .startOf("hour")
       .utc()


### PR DESCRIPTION
Utils was using `hh` without timezone, causing `NaN` error (due to strict check), when starting lottery