### PR TITLE
feat: Default gasLimit

### DIFF
--- a/scripts/close-lottery.ts
+++ b/scripts/close-lottery.ts
@@ -46,6 +46,7 @@ const main = async () => {
 
       // Create, sign and broadcast transaction.
       const tx = await contract.closeLottery(_lotteryId.toString(), {
+        gasLimit: 500000,
         gasPrice: _gasPrice.mul(2),
         from: operator.address,
       });

--- a/scripts/draw-lottery.ts
+++ b/scripts/draw-lottery.ts
@@ -37,6 +37,7 @@ const main = async () => {
 
       // Create, sign and broadcast transaction.
       const tx = await contract.drawFinalNumberAndMakeLotteryClaimable(_lotteryId.toString(), true, {
+        gasLimit: 500000,
         gasPrice: _gasPrice.mul(2),
         from: operator.address,
       });

--- a/scripts/start-lottery.ts
+++ b/scripts/start-lottery.ts
@@ -50,7 +50,7 @@ const main = async () => {
         config.Discount[networkName],
         config.Rewards[networkName],
         config.Treasury[networkName],
-        { gasPrice: _gasPrice.mul(2), from: operator.address }
+        { gasLimit: 500000, gasPrice: _gasPrice.mul(2), from: operator.address }
       );
 
       const message = `[${new Date().toISOString()}] network=${networkName} block=${_blockNumber.toString()} message='Started lottery' hash=${


### PR DESCRIPTION
Set a fixed `gasLimit` parameter when creating the transactions to force its broadcast and stop relying on the node state to estimate the gas (which can make a transaction not being broadcasted if the nodes is too delayed ending up in missing Chainlink VRF response).