### PR TITLE
fix: Config for Testnet network

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -20,11 +20,11 @@ export default {
   Ticket: {
     Price: {
       mainnet: 5,
-      testnet: 0.1,
+      testnet: 1,
     },
     Precision: {
       mainnet: 2,
-      testnet: 1,
+      testnet: 2,
     },
   },
   Discount: {


### PR DESCRIPTION
As now using Chainlink Price Feeds, the Ticket Price was too low and returning `0.0` as value; this PR aims to fix this by bumping the Ticket Price config to a full number + adding decimals (as mainnet network config)